### PR TITLE
fix: remove outdated rotate 90 test in tests/image_rotation_tests.c

### DIFF
--- a/tests/image_rotation_tests.c
+++ b/tests/image_rotation_tests.c
@@ -47,81 +47,6 @@ int find_best_rotation_angle(char *filename, char *image_print_name,
     return result;
 }
 
-int test_rotate_90()
-{
-    print_test_subcategory("Rotate 90 Degrees Tests");
-
-    GdkPixbuf *pixbuf = load_image("level_1_image_1.png");
-    if (!pixbuf)
-    {
-        print_fail();
-        printf("Failed to load image\n");
-        return 0;
-    }
-
-    GdkPixbuf *rotated = rotate_image(pixbuf, 90);
-    if (!rotated)
-    {
-        print_fail();
-        printf("Rotation failed\n");
-        g_object_unref(pixbuf);
-        return 0;
-    }
-
-    int width = gdk_pixbuf_get_width(pixbuf);
-    int height = gdk_pixbuf_get_height(pixbuf);
-    int new_width = gdk_pixbuf_get_width(rotated);
-    int new_height = gdk_pixbuf_get_height(rotated);
-
-    // Basic dimension check
-    int is_rotation_correct = (new_width >= height && new_height >= width);
-    if (!is_rotation_correct)
-    {
-        print_fail();
-        printf("Rotated dimensions incorrect (original %dx%d, rotated %dx%d)\n",
-               width, height, new_width, new_height);
-    }
-    else
-    {
-        print_success();
-        printf("Rotated dimensions are correct\n");
-    }
-
-    int n_channels = gdk_pixbuf_get_n_channels(pixbuf);
-    guchar *pixels = gdk_pixbuf_get_pixels(pixbuf);
-
-    guchar *top_left = pixels;
-    guchar *rot_pixels = gdk_pixbuf_get_pixels(rotated);
-    int rot_rowstride = gdk_pixbuf_get_rowstride(rotated);
-
-    guchar *new_top_left = rot_pixels + 0 * rot_rowstride + 0 * n_channels;
-    int pixel_same = 1;
-    for (int c = 0; c < n_channels; c++)
-    {
-        if (top_left[c] != new_top_left[c])
-        {
-            pixel_same = 0;
-            break;
-        }
-    }
-
-    if (!pixel_same)
-    {
-        print_success();
-        printf("Top-left pixel moved as expected\n");
-    }
-    else
-    {
-        print_fail();
-        printf("Top-left pixel did not move\n");
-        is_rotation_correct = 0;
-    }
-
-    g_object_unref(pixbuf);
-    g_object_unref(rotated);
-    return is_rotation_correct;
-}
-
 int test_detect_best_angle()
 {
     print_test_subcategory("Detect Best Angle Tests");
@@ -148,7 +73,6 @@ int main()
 
     int passed = 1;
 
-    passed &= test_rotate_90();
     passed &= test_detect_best_angle();
 
     if (passed)


### PR DESCRIPTION
### Image Rotation Tests Fix
* Removed Rotate 90° Test because automatic rotation already tests rotation and the test is outdated (uses center-based rotation now)